### PR TITLE
Dep updates, and version bump.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.6.9]
+- New method `get-object-input-stream` which returns the raw object input stream,
+  instead of a string.
+- Bump AWS SDK to `1.11.215` (Updated 18 October 2017)
+- Remove `joda-time` exclusion so the library can be used by projects
+  that don't include it.
+
+### Fixed
+- Clojure 1.9 compatibility
 ## [0.6.8]
 ### Fixed
 - Clojure 1.9 compatibility

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A simple library to access Amazon S3 from Clojure.
 
 First, add `snake` to your `project.clj`:
 
-`[snake "0.6.7"]`
+`[snake "0.6.9"]`
 
 `snake`, by default, tries to use the **instance profiles** set in `~/.aws/credentials`. However, if you have setup snake already with `snake/setup!`, then `snake` will use these details instead.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject snake "0.6.8"
+(defproject snake "0.6.9"
 
   :description "Snake: S3 interop for Clojure."
 
@@ -19,4 +19,4 @@
                   ["vcs" "push"]]
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.amazonaws/aws-java-sdk-s3 "1.9.39" :exclusions [joda-time]]])
+                 [com.amazonaws/aws-java-sdk-s3 "1.11.215"]])


### PR DESCRIPTION
- Update AWS SDK to the lastest version.
- Remove joda-time exclusion.
- Bump version, and update README.